### PR TITLE
Enable `ruff-format` hook in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix]
-      #- id: ruff-format
-      #  types_or: [ python, pyi, jupyter ]
+      - id: ruff-format
+        types_or: [ python, pyi, jupyter ]
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ extend-select = [
   "S",   # bandit - https://docs.astral.sh/ruff/rules/#flake8-bandit-s
   "UP",  # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
+ignore = [
+  "RUF012",  # TODO: Mutable class attributes should be annotated with `typing.ClassVar`
+]
+per-file-ignores."tests/**" = [
+  "S101",  # Use of `assert` detected
+]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,17 +83,13 @@ select = [
     "F",  # pyflakes
 ]
 extend-select = [
-    "I",  # isort
-]
-ignore = [
-    "E501",  # line too long
-    "E722",  # do not use bare `except`
-    "E741",  # ambiguous variable name
-    "F401",  # imported but unused
-    "F403",  # `from ... import *` used
-    "F405",  # may be undefined from star imports
-    "E721",  # use `is` for type comparisons
-    "F821",  # undefined name
+  "A",   # flake8-builtins - https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+  "I",   # isort - https://docs.astral.sh/ruff/rules/#isort-i
+  "PT",  # pytest - https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
+  "Q",   # flake8-quotes - https://docs.astral.sh/ruff/rules/#flake8-quotes-q
+  "RUF", # Ruff-specific rules - https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+  "S",   # bandit - https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+  "UP",  # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
 
 [tool.pytest.ini_options]

--- a/src/rfdetr_plus/__init__.py
+++ b/src/rfdetr_plus/__init__.py
@@ -19,6 +19,6 @@ __docs__ = "https://rfdetr.roboflow.com"
 from rfdetr_plus.models import RFDETR2XLarge, RFDETRXLarge
 
 __all__ = [
-    "RFDETRXLarge",
     "RFDETR2XLarge",
+    "RFDETRXLarge",
 ]

--- a/src/rfdetr_plus/models/__init__.py
+++ b/src/rfdetr_plus/models/__init__.py
@@ -8,8 +8,8 @@
 from rfdetr_plus.models.detection import RFDETR2XLarge, RFDETR2XLargeConfig, RFDETRXLarge, RFDETRXLargeConfig
 
 __all__ = [
-    "RFDETRXLarge",
-    "RFDETRXLargeConfig",
     "RFDETR2XLarge",
     "RFDETR2XLargeConfig",
+    "RFDETRXLarge",
+    "RFDETRXLargeConfig",
 ]


### PR DESCRIPTION
This pull request makes a small change to the `.pre-commit-config.yaml` file by enabling the `ruff-format` hook for Python, Pyi, and Jupyter files. This ensures that code formatting is automatically applied to these file types during pre-commit checks.
