### PR TITLE
Refactor model assets structure, for `rfdetr` 1.4.3+

### DIFF
--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv pip install -e . --group tests
 
       - name: Run the Test
-        run: uv run pytest -m "not gpu" --cov=rfdetr_plus --cov-report=xml
+        run: pytest -m "not gpu" --cov=rfdetr_plus --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 keywords = ["machine-learning", "deep-learning", "vision", "ML", "DL", "AI", "DETR", "RF-DETR", "Roboflow"]
 
 dependencies = [
-    "rfdetr>=1.4.1,<2",
+    "rfdetr>=1.4.3,<2",
 ]
 
 [project.optional-dependencies]

--- a/src/rfdetr_plus/assets/__init__.py
+++ b/src/rfdetr_plus/assets/__init__.py
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------
+# RF-DETR+
+# Copyright (c) 2026 Roboflow, Inc. All Rights Reserved.
+# Licensed under the Platform Model License 1.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""RF-DETR+ model assets module."""
+
+from rfdetr_plus.assets.model_weights import ModelWeights
+
+__all__ = ["ModelWeights"]

--- a/src/rfdetr_plus/assets/model_weights.py
+++ b/src/rfdetr_plus/assets/model_weights.py
@@ -1,0 +1,54 @@
+# ------------------------------------------------------------------------
+# RF-DETR+
+# Copyright (c) 2026 Roboflow, Inc. All Rights Reserved.
+# Licensed under the Platform Model License 1.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""
+RF-DETR+ Model weights registry.
+
+Provides ModelWeights enum for platform-licensed large-scale models,
+compatible with rf-detr's asset structure introduced in version 1.4.3.
+"""
+
+from rfdetr.assets.model_weights import ModelWeightAsset, ModelWeightsBase
+
+
+class ModelWeights(ModelWeightsBase):
+    """
+    Enumeration of RF-DETR+ platform-licensed model assets.
+
+    Inherits from rf-detr's ModelWeightsBase to ensure compatibility.
+
+    Each enum member's value is a ModelWeightAsset instance containing:
+    - filename: The local filename for the model weights
+    - url: The download URL
+    - md5_hash: The expected MD5 hash for integrity validation
+
+    Example:
+        >>> from rfdetr_plus.assets import ModelWeights
+        >>> asset = ModelWeights.RF_DETR_XLARGE
+        >>> asset.filename
+        'rf-detr-xlarge.pth'
+        >>> asset.url
+        'https://storage.googleapis.com/rfdetr/platform-licensed/rf-detr-xlarge.pth'
+    """
+
+    # Platform-Licensed Detection Models (XLarge and 2XLarge)
+    # These models are subject to the Platform Model License 1.0
+    RF_DETR_XLARGE = ModelWeightAsset(
+        "rf-detr-xlarge.pth",
+        "https://storage.googleapis.com/rfdetr/platform-licensed/rf-detr-xlarge.pth",
+        None,  # MD5 hash to be added when available
+    )
+    RF_DETR_XXLARGE = ModelWeightAsset(
+        "rf-detr-xxlarge.pth",
+        "https://storage.googleapis.com/rfdetr/platform-licensed/rf-detr-xxlarge.pth",
+        None,  # MD5 hash to be added when available
+    )
+
+    # All methods inherited from ModelWeightsBase:
+    # - from_filename(filename) -> Optional[ModelWeightAsset]
+    # - get_url(filename) -> Optional[str]
+    # - get_md5(filename) -> Optional[str]
+    # - list_models() -> list[str]

--- a/src/rfdetr_plus/assets/model_weights.py
+++ b/src/rfdetr_plus/assets/model_weights.py
@@ -39,12 +39,12 @@ class ModelWeights(ModelWeightsBase):
     RF_DETR_XLARGE = ModelWeightAsset(
         "rf-detr-xlarge.pth",
         "https://storage.googleapis.com/rfdetr/platform-licensed/rf-detr-xlarge.pth",
-        None,  # MD5 hash to be added when available
+        "6ddf834f2bc5bed3214a82f9b0aaeed7",
     )
     RF_DETR_XXLARGE = ModelWeightAsset(
         "rf-detr-xxlarge.pth",
         "https://storage.googleapis.com/rfdetr/platform-licensed/rf-detr-xxlarge.pth",
-        None,  # MD5 hash to be added when available
+        "e3204689c1f0280427e4c33e6a2ac6cd",
     )
 
     # All methods inherited from ModelWeightsBase:

--- a/src/rfdetr_plus/models/downloads.py
+++ b/src/rfdetr_plus/models/downloads.py
@@ -4,7 +4,15 @@
 # Licensed under the Platform Model License 1.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-PLATFORM_MODELS = {
-    "rf-detr-xlarge.pth": "https://storage.googleapis.com/rfdetr/platform-licensed/rf-detr-xlarge.pth",
-    "rf-detr-xxlarge.pth": "https://storage.googleapis.com/rfdetr/platform-licensed/rf-detr-xxlarge.pth",
-}
+"""
+Legacy model downloads dictionary.
+
+DEPRECATED: Use rfdetr_plus.assets.ModelWeights instead.
+This dictionary is maintained for backward compatibility only.
+"""
+
+from rfdetr_plus.assets import ModelWeights
+
+# Legacy dictionary for backward compatibility
+# New code should use rfdetr_plus.assets.ModelWeights
+PLATFORM_MODELS = {asset.filename: asset.url for asset in ModelWeights}

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -11,7 +11,6 @@ import pytest
 from rfdetr_plus import RFDETR2XLarge, RFDETRXLarge
 
 
-@pytest.mark.gpu
 @pytest.mark.parametrize(
     ("model_class", "resolution"),
     [

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,15 +8,22 @@
 import numpy as np
 import pytest
 
-from rfdetr_plus import RFDETRXLarge
+from rfdetr_plus import RFDETR2XLarge, RFDETRXLarge
 
 
 @pytest.mark.gpu
-def test_model_inference() -> None:
-    """Test that we can instantiate RF-DETR+ XLarge and run inference."""
+@pytest.mark.parametrize(
+    ("model_class", "resolution"),
+    [
+        (RFDETRXLarge, 700),
+        (RFDETR2XLarge, 880),
+    ],
+)
+def test_model_inference(model_class, resolution) -> None:
+    """Test that we can instantiate RF-DETR+ models and run inference."""
     # Instantiate and run inference
-    rf_detr = RFDETRXLarge()
-    dummy_image = np.random.randint(0, 255, (700, 700, 3), dtype=np.uint8)
+    rf_detr = model_class()
+    dummy_image = np.random.randint(0, 255, (resolution, resolution, 3), dtype=np.uint8)
 
     # Run inference - this verifies the model can be instantiated and used
     predictions = rf_detr.predict(dummy_image, conf_threshold=0.1)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,10 +5,21 @@
 # ------------------------------------------------------------------------
 """Test basic package functionality."""
 
+import numpy as np
+import pytest
 
-def test_version() -> None:
-    """Test that the package version is accessible."""
-    from rfdetr_plus import __version__
+from rfdetr_plus import RFDETRXLarge
 
-    assert isinstance(__version__, str)
-    assert len(__version__) > 0
+
+@pytest.mark.gpu
+def test_model_inference() -> None:
+    """Test that we can instantiate RF-DETR+ XLarge and run inference."""
+    # Instantiate and run inference
+    rf_detr = RFDETRXLarge()
+    dummy_image = np.random.randint(0, 255, (700, 700, 3), dtype=np.uint8)
+
+    # Run inference - this verifies the model can be instantiated and used
+    predictions = rf_detr.predict(dummy_image, conf_threshold=0.1)
+
+    # Verify predictions were returned
+    assert predictions is not None


### PR DESCRIPTION
This pull request introduces a new asset management system for RF-DETR+ model weights, aligning with the updated asset structure in `rf-detr` version 1.4.3. The changes add a new `ModelWeights` enum for platform-licensed models, update dependencies, and deprecate the old download dictionary in favor of the new approach. These updates make it easier and more robust to reference and manage model weights in the codebase.

**Asset management improvements:**
* Added a new `ModelWeights` enum in `rfdetr_plus.assets.model_weights` that inherits from `ModelWeightsBase` and provides structured access to platform-licensed model weights, including filenames, URLs, and MD5 hashes. This improves compatibility and maintainability for large-scale models.
* Introduced the `rfdetr_plus.assets` module with an `__init__.py` that exposes `ModelWeights` for use throughout the codebase.

**Dependency updates:**
* Updated the `rfdetr` dependency version in `pyproject.toml` to `>=1.4.3,<2` to ensure compatibility with the new asset structure.

**Backward compatibility and deprecation:**
* Deprecated the legacy `PLATFORM_MODELS` dictionary in `rfdetr_plus/models/downloads.py`, replacing it with a dynamically generated dictionary based on the new `ModelWeights` enum, while maintaining backward compatibility.